### PR TITLE
fix: double 'requestId' in HandleRequest

### DIFF
--- a/assets/app/index.js
+++ b/assets/app/index.js
@@ -195,23 +195,26 @@ function handleWallpaperLoaded(monitorId) {
 }
 
 function handleRequest(msg) {
-    console.log('recieved request', msg)
+    console.log('recieved request', msg); 
     const monitorId = msg['monitor-id'];
     if (!monitorId)
         return;
     const id = userPrefs.selected[monitorId]
     if (!id)
         return;
+
     const response = {
         "type": "response",
         "requestId": msg.requestId,
         "requestType": msg.requestType
     };
+
     switch (msg.requestType) {
         case 'options':
             response['data'] = userPrefs.modOptions[id];
             break;
         default:
+            console.warn('Unknown request type: ${msg.requestType}');
             break;
     }
     console.log('sending', { type: 'send-to-wallpaper', 'monitor-id': monitorId, data: response });

--- a/src/API/API.cpp
+++ b/src/API/API.cpp
@@ -94,7 +94,7 @@ void SendEventToHwnd(HWND hwnd, json msg, json data, bool mainThread)
 void HandleRequest(json msg, HWND hwnd)
 {
     if (msg.contains("requestId") && msg.contains("requestType") &&
-        msg["requestId"].is_string() && msg["requestId"].is_string())
+        msg["requestId"].is_string() && msg["requestType"].is_string())
     {
         std::string type = msg["requestType"];
         if (type == "options" || false) // handled by app_hwnd
@@ -170,6 +170,11 @@ void HandleRequest(json msg, HWND hwnd)
                     RespondToHwnd(hwnd, msg, IsWindowVisible(listView) ? true : false);
             }
         }
+    }
+    else 
+    {
+        std::string type = msg["requestType"];
+        wprintf(L"Unknown request type: %hs\n", type.c_str());
     }
 }
 


### PR DESCRIPTION
Fixed double `requestId` string checking and added logging for  unknown `requestType`.

Also I added logs to js and cpp both to provide clear visibility of what happening on the frontend and backend.